### PR TITLE
Read servers also from `servers_config_local.json`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Local server configuration
+servers_config_local.json
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/mcp_simple_slackbot/main.py
+++ b/mcp_simple_slackbot/main.py
@@ -711,10 +711,24 @@ async def main() -> None:
             "SLACK_BOT_TOKEN and SLACK_APP_TOKEN must be set in environment variables"
         )
 
+    # Load main server configuration
     server_config = config.load_config("servers_config.json")
+    all_servers = server_config["mcpServers"].copy()
+
+    # Load and merge local server configuration if it exists
+    try:
+        local_server_config = config.load_config("servers_config_local.json")
+        if "mcpServers" in local_server_config:
+            all_servers.update(local_server_config["mcpServers"])
+            logging.info(f"Merged {len(local_server_config['mcpServers'])} servers from servers_config_local.json")
+    except FileNotFoundError:
+        logging.info("No servers_config_local.json found, using only main configuration")
+    except Exception as e:
+        logging.warning(f"Error loading servers_config_local.json: {e}")
+
     servers = [
         Server(name, srv_config)
-        for name, srv_config in server_config["mcpServers"].items()
+        for name, srv_config in all_servers.items()
     ]
 
     llm_client = LLMClient(config.llm_api_key, config.llm_model)


### PR DESCRIPTION
Because previously I had to modify `servers_config.json` and then that git-managed file shows up as being modified and it's easy to accidentally commit it and even if I don't commit it, it might make switching branches or rebasing harder because it's modified.

Solution is to also load from a `servers_config_local.json` file which is not committed to git (in fact, it's in `.gitignore`) so I can do all my local customizations there without messing up git.